### PR TITLE
"Silent" end party

### DIFF
--- a/annexlang/components.py
+++ b/annexlang/components.py
@@ -128,8 +128,8 @@ class ProtocolStep(ProtocolObject):
             line_counter = 0
             out = ""
             for line in self.lines_below:
-                pos = "8pt" + ("+8pt" * line_counter)
-                out += r"""node [%s,below=%s,anchor=base](%s){%s} """ % (
+                pos = "1.5pt" + ("+8pt" * line_counter)
+                out += r"""node [anchor=north,inner sep=0pt,%s,below=%s](%s){%s} """ % (
                     self.text_style,
                     pos,
                     self.create_affecting_node_name(parties=[]),

--- a/annexlang/language.py
+++ b/annexlang/language.py
@@ -282,6 +282,8 @@ class EndParty(ProtocolStep):
     
     def tikz(self):
         pos = self.get_pos(self.party.column, self.line)
+        if getattr(self, 'silent', False):
+            return fr"""\node[name={self.node_name}] at ({pos}) {{}};"""
         text = self.party.name
         out = ""
         if getattr(self.party, "multiple", False):
@@ -294,6 +296,8 @@ class EndParty(ProtocolStep):
 
     @property
     def height(self):
+        if getattr(self, 'silent', False):
+            return "0ex", "center"
         return "5ex", "center"
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,6 +117,7 @@ All non-dummy parties have to be started and ended in order to be visible.
   party: *browser  # Required
 - !end-party
   party: *browser  # Required
+  silent: false    # Hide the end party node (default false)
 ```
 
 ![](start_stop_browser.png)


### PR DESCRIPTION
Paper page limits :-1: ... Anyway, this PR adds an option `silent` for `end-party` elements which changes the end-party TikZ node such that it is present (needed, e.g., for grouping), but does not produce visible output, making the resulting TikZ picture a bit smaller.