### PR TITLE
Fix note position on script action

### DIFF
--- a/annexlang/components.py
+++ b/annexlang/components.py
@@ -128,8 +128,8 @@ class ProtocolStep(ProtocolObject):
             line_counter = 0
             out = ""
             for line in self.lines_below:
-                pos = "8pt" + ("+8pt" * line_counter)
-                out += r"""node [%s,below=%s,anchor=base](%s){%s} """ % (
+                pos = "1.5pt" + ("+8pt" * line_counter)
+                out += r"""node [anchor=north,inner sep=0pt,%s,below=%s](%s){%s} """ % (
                     self.text_style,
                     pos,
                     self.create_affecting_node_name(parties=[]),

--- a/annexlang/components.py
+++ b/annexlang/components.py
@@ -128,8 +128,8 @@ class ProtocolStep(ProtocolObject):
             line_counter = 0
             out = ""
             for line in self.lines_below:
-                pos = "1.5pt" + ("+8pt" * line_counter)
-                out += r"""node [anchor=north,inner sep=0pt,%s,below=%s](%s){%s} """ % (
+                pos = "8pt" + ("+8pt" * line_counter)
+                out += r"""node [%s,below=%s,anchor=base](%s){%s} """ % (
                     self.text_style,
                     pos,
                     self.create_affecting_node_name(parties=[]),

--- a/annexlang/language.py
+++ b/annexlang/language.py
@@ -259,6 +259,34 @@ class ScriptAction(Action):
         return fr"""%% draw script action arrow
         \draw[annex_script_action_arrow{rev}{self.tikz_extra_style}] ({self.node_name}.{direction}) to  {self.tikz_above} ({dest});"""
 
+    def tikz_notes(self):
+        is_left_to_right = self.src.column < self.dest.column
+        dest = self.get_pos(self.dest.column, self.line)
+        out = ""
+        if hasattr(self, 'note_right'):
+            note_right_for_tex = str(self.note_right).strip().replace('\n', '\\\\')
+            if is_left_to_right:
+                # Position note relative to action arrow target
+                note_base_pos = dest
+            else:
+                # Position note relative to action label node
+                note_base_pos = self.node_name
+            out += fr"""\node[right=1pt of {note_base_pos},anchor=west,
+                            inner sep=0pt,annex_note{self.tikz_note_style}
+                           ] {'{' + self.contour(note_right_for_tex) + '}'}; """
+        if hasattr(self, 'note_left'):
+            note_left_for_tex = str(self.note_left).strip().replace('\n', '\\\\')
+            if is_left_to_right:
+                # Position note relative to action label node
+                note_base_pos = self.node_name
+            else:
+                # Position note relative to action arrow target
+                note_base_pos = dest
+            out += fr"""\node[left=1pt of {note_base_pos},anchor=east,
+                            inner sep=0pt,annex_note{self.tikz_note_style}
+                           ] {'{' + self.contour(note_left_for_tex) + '}'}; """
+        return out
+
     @property
     def height(self):
         return "4ex", "center"


### PR DESCRIPTION
The positioning of notes was previously just inherited from regular actions, i.e., the notes were placed left/right of the action node, ignoring the arrow that is present in script actions.

With this PR, a note_left is always placed to the left of the leftmost element of the script action (i.e., the action node if the src is left of the dest, or vice-versa otherwise); and a right_node always to the right of the rightmost element.

### Example

```yaml
- !script-action
  id: fill-login-form
  src: *browser
  dest: *auths
  label: |
    \parbox{.135\textwidth}{\raggedright Run script (fill out and submit login form)}
  data: \mi{auth2reference}, form data (i.e., credentials)
  note_right: \str{/auth2}
  note_style: endpoint
```

Before:
![image](https://github.com/danielfett/annexlang/assets/9265790/8791c3bb-dd1a-44d8-a358-4d234f2bd98a)

After:
![image](https://github.com/danielfett/annexlang/assets/9265790/69ff2527-98ee-41c6-afec-5a528378eba9)
